### PR TITLE
docs: Phase C hardening plan and refreshed README draft

### DIFF
--- a/PHASE_C_HARDENING.md
+++ b/PHASE_C_HARDENING.md
@@ -1,0 +1,259 @@
+# Rambling Guardian — Phase C Hardening Plan
+
+This document locks the decisions that must be made before Phase D AI coaching work begins.
+
+## Why this exists
+
+The project has working firmware, a BLE-connected Expo companion app, exercises, history, settings, and notifications. The biggest risk now is building AI/coaching features on top of incomplete sync rules, unclear session semantics, weak persistence, or unmeasured battery behavior.
+
+This hardening pass exists to prevent building on broken windows.
+
+## Product direction
+
+- The **device** is the primary sensing surface.
+- The **phone app** is the companion, review, settings, and coaching surface.
+- The **cloud** is optional until Phase D.0 and should not be required for core device use.
+- The product must still work when the phone is absent, disconnected, locked, interrupted by alarms/calls, or relaunched later.
+
+## Current truths to align in docs/code
+
+- Vibration hardware is wired and should no longer be documented as pending.
+- The button map has changed from the stale README.
+- The companion app exists and is part of the real product.
+- Favorites are implemented inline in Exercises and should be treated as shipped for Phase C.
+- The calendar layout has a visible right-edge alignment bug that must be fixed before Phase D.
+
+## Phase C hardening goals
+
+1. **Truthful docs**
+   - README reflects current firmware + app behavior.
+   - Session definitions are explicit.
+   - Hardware button shortcuts are taught in-app.
+
+2. **Reliable persistence**
+   - App settings persist across relaunch.
+   - Device thresholds and sync state persist across reboot.
+
+3. **Reliable reconnect + resync**
+   - Device can be used without the phone nearby.
+   - Phone can reconnect later and safely import missing sessions/events.
+   - Mid-sync failure does not duplicate or lose data.
+
+4. **Battery + power safety**
+   - Battery readings are calibrated and smoothed.
+   - Recording/sync behavior respects battery thresholds.
+   - Portable battery sizing is based on measured current, not guesses.
+
+5. **Test coverage**
+   - Edge cases and failure modes are explicitly tested before Phase D.
+
+## Core semantics
+
+### Session
+A **session** is an automatically segmented conversational window detected on-device.
+
+Suggested start rule:
+- start a new session when speech has been detected after a sufficiently long quiet period
+
+Suggested end rule:
+- end the session after a sufficiently long trailing silence or after explicit manual stop
+
+### Speaking run
+A **speaking run** is one continuous user-speaking span inside a session.
+
+### Alert event
+An **alert event** is a threshold crossing inside a speaking run.
+It should store:
+- stable event id
+- session id
+- speaking run id
+- timestamp offset from session start
+- alert level
+- duration at alert
+
+### Manual capture
+A **manual capture** is a user-triggered recording and must remain separate from auto-detected sessions.
+
+### Synced from device
+A session marked `synced_from_device` means:
+- the session originated on the wearable
+- the phone imported it later from the device backlog
+- it was not originally created live on the phone
+
+## Sync protocol
+
+### Requirements
+- Device must store backlog locally.
+- Phone must ask for a **manifest** on reconnect.
+- Sync must be resumable.
+- Writes must be idempotent.
+- Device must not mark items as synced until they are acknowledged.
+
+### Manifest model
+The device should expose:
+- pending session count
+- pending speaking run count
+- pending alert event count
+- pending manual capture count
+- estimated bytes/chunks pending
+- device sync checkpoint id
+
+### Transfer model
+1. Phone connects.
+2. Phone reads current live state.
+3. Phone requests sync manifest.
+4. Phone requests unsynced items in deterministic order.
+5. Device sends chunk(s).
+6. Phone writes locally using upsert semantics.
+7. Phone acks the chunk/item.
+8. Device advances checkpoint only after ack.
+
+### Mid-sync failure behavior
+If sync breaks:
+- unacked items remain pending on device
+- locally written items must be safe to replay without duplication
+- reconnect resumes from last acked checkpoint
+
+### UI expectations
+The app should show:
+- `Syncing 2 of 9 sessions`
+- `Last synced 12m ago`
+- `3 sessions waiting to review`
+- `Synced from device` badge on imported items
+- `New` indicator for newly imported sessions
+
+## Audio retention policy
+
+The product should not keep raw all-day audio by default.
+
+### Default retention tiers
+1. **Always keep metadata**
+   - sessions
+   - speaking runs
+   - alert events
+   - summaries/insights later
+
+2. **Manual voice notes**
+   - kept in full until the user deletes them
+   - user can optionally archive or export them
+
+3. **Auto-detected sessions**
+   - default to metadata only
+   - optionally keep short flagged audio clips
+
+4. **Long meetings / valuable memories**
+   - prompt after sync:
+     - Keep summary only
+     - Keep summary + key clips
+     - Keep full audio
+     - Delete audio, keep metadata
+
+### Practical policy
+- Keep **transcript + summary + key clips** for most sessions.
+- Keep **full audio** only for intentional saves, manual voice notes, or explicitly preserved meetings/memories.
+- Raw audio should be transcoded/compressed after sync when possible rather than stored forever in raw PCM.
+
+## Battery and power policy
+
+### Product rules
+- The device should not suddenly die mid-meeting without attempting a safe flush.
+- The device should avoid starting long recordings when battery is already too low.
+- Critical battery should trigger a **safe-stop**, not abrupt loss.
+
+### Recommended battery states
+These are product policy targets and should be tuned after power profiling.
+
+- **Normal zone**: all features available
+- **Low battery zone**: warn user, reduce LED brightness, avoid nonessential sync chatter
+- **Capture guard zone**: do not start new manual recordings or optional bulk sync
+- **Critical reserve zone**: finalize current file/session, persist sync markers, then enter protected shutdown/deep sleep
+
+### Behavior expectations
+- If the battery becomes critically low during recording:
+  - stop accepting new capture frames after reserve is hit
+  - close the file cleanly
+  - write final metadata/checkpoint
+  - mark the session as recoverable/importable later
+  - warn the user if possible before shutdown
+
+## Cloud foundation (Phase D.0)
+
+Recommended stack:
+- **Firestore** for metadata and sync state
+- **Storage** for optional audio blobs
+- **Google Drive** for archive/export, not primary operational state
+
+Suggested cloud entities:
+- devices
+- sessions
+- speaking_runs
+- alert_events
+- manual_captures
+- sync_checkpoints
+
+## Apple Watch future role
+
+Apple Watch should be treated as a **fast control surface**, not the primary sensing brain.
+
+Good candidates:
+- reconnect guardian
+- toggle presentation mode
+- start manual capture
+- mark this conversation
+- find/search for device
+
+Avoid making the first watch version responsible for full BLE orchestration or primary coaching logic.
+
+## Testing matrix
+
+### Firmware
+- threshold transitions
+- pause-reset logic
+- session boundary rules
+- battery low/critical behavior
+- mode switching behavior
+- capture mode edge cases
+- persistence across reboot
+
+### App logic
+- settings persistence/hydration
+- BLE reconnect state machine
+- sync progress state
+- partial sync failure + resume
+- duplicate replay protection
+- imported session rendering
+- favorites discoverability flows
+- calendar layout regression
+
+### Sync protocol
+- empty backlog
+- one item backlog
+- large backlog
+- mid-sync disconnect
+- duplicate chunk replay
+- corrupted chunk
+- ack lost after local write
+- device reboot during sync
+- phone app killed during sync
+- reconnect after stale watermark
+
+### Manual hardware verification
+- use without phone nearby
+- reconnect after hours
+- sync while screen locked
+- sync after alarm/call interruption
+- low battery during sync
+- manual capture during pending sync
+- BLE reconnect after dev build reload
+
+## Immediate implementation order
+
+1. README truth pass
+2. settings persistence
+3. BLE reconnect/sync state machine
+4. session semantics + history timestamp fix
+5. battery calibration + safe-stop policy
+6. calendar bug fix
+7. notification truth pass
+8. power profiling
+9. Phase D.0 cloud prep

--- a/PHASE_PLAN_VNEXT.md
+++ b/PHASE_PLAN_VNEXT.md
@@ -1,0 +1,62 @@
+# Rambling Guardian — Proposed Next Phase Plan
+
+This is a drop-in replacement draft for `PHASE_PLAN.md` until the tracked file is updated directly.
+
+## Changes from current plan
+
+- Mark `RG-C.4.10` complete because favorites are already implemented.
+- Split notification work into final hardening tasks instead of treating it as fully finished.
+- Add a new **Phase C.11 — Hardening Before AI Coaching** section.
+- Add a new **Phase D.0 — Cloud Foundation + Sync Model** section.
+- Rewrite Phase D around device-first segmentation, sync, speaker attribution, context classification, and coaching.
+- Keep Post-Launch items as future follow-up work.
+
+## Proposed additions to Phase C
+
+### Phase C.11 — Hardening Before AI Coaching
+- README truth pass
+- session semantics
+- hardware shortcuts/help section
+- persisted settings
+- real device info in settings
+- BLE reconnect/disconnect/forget-device flows
+- BLE sync state machine
+- synced-from-device backlog model
+- resumable sync with ack/retry semantics
+- history timestamp correctness
+- calendar layout bug fix
+- favorites discoverability improvement
+- battery calibration + safe-stop policy
+- power profiling
+- firmware/app/manual test matrices
+
+## Proposed additions before cloud coaching
+
+### Phase D.0 — Cloud Foundation + Sync Model
+- Firestore for metadata
+- Storage for optional audio blobs
+- Google Drive for archive/export only
+- sync checkpoints / watermarks
+- retention policy for metadata vs audio
+- cloud retry/resume tests
+
+## Proposed rewrite of Phase D
+
+### Phase D — Device-First Coaching + Insights
+- device-first session segmentation + local backlog
+- optional compressed audio / flagged clip sync
+- voice enrollment + speaker attribution
+- context classification: solo, couple, meeting, presentation, background TV/noise
+- coaching engine: fillers, pacing, interruption patterns, overlong runs, reflection prompts
+- exercise recommendation engine
+- post-session summaries + insights
+- backup/export flow
+
+## Notes to keep explicit
+
+- The device must still work without the phone nearby.
+- Mid-sync failure must resume cleanly.
+- Long meetings/memories may need user prompts to keep summary only vs full audio.
+- Manual captures and auto-detected sessions must remain distinct.
+- Low battery should safe-stop recording instead of abruptly losing state.
+- Apple Watch remains deferred as deeper integration, but quick-control actions remain a valid future direction.

--- a/README_REFRESH.md
+++ b/README_REFRESH.md
@@ -1,0 +1,158 @@
+# Rambling Guardian
+
+Wearable speech-awareness and coaching system built on **Seeed XIAO ESP32S3 Sense** with a connected **React Native Expo companion app**.
+
+Rambling Guardian is no longer just a firmware prototype. The product now has:
+- on-device speech-duration monitoring
+- LED + vibration alerts
+- BLE companion app
+- live session dashboard
+- local history and analytics
+- settings + threshold configuration
+- voice-training exercises
+- manual capture mode with SD-backed recording
+
+## Current product position
+
+The project is in **late Phase C**:
+- firmware + app are working
+- the next priority is **hardening** before AI coaching work
+- the biggest remaining areas are reconnect/resync reliability, persistence, session semantics, battery truth, and power profiling
+
+## Core behavior
+
+The wearable monitors continuous speech and escalates alerts:
+- **Green** breathing: all clear
+- **Yellow**: gentle nudge
+- **Orange**: time to wrap up
+- **Red**: urgent
+- **Blinking red**: critical
+
+The phone app is the companion surface for:
+- connection state
+- history/review
+- exercises
+- settings
+- future coaching/insights
+
+## Hardware
+
+### Current components
+- Seeed XIAO ESP32S3 Sense
+- built-in PDM microphone
+- built-in RGB LED
+- tactile push button
+- vibration motor
+- LiPo battery
+- SD card support for manual capture mode
+
+### Wiring notes
+- button on D1 / GPIO 2
+- vibration motor on D2 / GPIO 3
+- battery ADC on D3 / GPIO 4 via divider
+- built-in mic on GPIO 41 / 42
+
+## Button controls
+
+- **Single press**: toggle Monitoring ↔ Presentation mode
+- **Double press**: start/stop manual capture mode
+- **Triple press**: cycle alert modality (both, LED-only, vibration-only)
+- **Long press**: enter deep sleep
+
+## Modes
+
+### Monitoring
+Normal guardian mode. The device tracks continuous speaking duration and issues alerts.
+
+### Presentation
+Suppresses normal alerting so intentional long-form speaking does not feel like rambling.
+
+### Manual capture
+Explicit recording mode for saved voice notes, memories, or intentional captures.
+
+### Deep sleep
+Power-saving state entered manually or later by battery protection logic.
+
+## Architecture
+
+The firmware uses an event-driven pub/sub design so modules stay decoupled.
+
+Examples:
+- Audio input publishes speech started / ended events
+- Speech timer publishes alert-level changes
+- LED/vibration/BLE/session logging react to events
+- Button input publishes user-intent events to mode/capture logic
+
+## Companion app surfaces
+
+### Home
+Quick daily context, exercises, and device connection summary.
+
+### Session
+Live BLE dashboard for current speech duration, alert state, battery, and device stats.
+
+### Exercises
+Offline exercise library, daily practice, streaks, favorites, and active exercise flow.
+
+### History
+Recent sessions, timelines, analytics, and later coaching entry point.
+
+### Settings
+Thresholds, modality, reminders, and product/device information.
+
+## Product principles
+
+- **Device first**: the wearable should keep working even when the phone is absent.
+- **Phone as companion**: the phone should catch up later and present review/coaching clearly.
+- **Metadata always, audio selectively**: keep summaries/events by default, keep full audio only when it is intentional or explicitly preserved.
+- **Hardening before AI**: Phase D coaching depends on clean sync and trustworthy session semantics.
+
+## Known hardening priorities
+
+- reconnect/resync without app restarts
+- persistent settings + thresholds
+- synced-from-device backlog import
+- history timestamp correctness
+- calendar layout bug in exercises/streak screen
+- battery calibration + safe-stop recording behavior
+- power profiling for portable battery sizing
+
+## Audio retention direction
+
+Raw 16 kHz / 16-bit mono audio is too heavy for all-day default storage.
+
+Planned policy:
+- always keep session metadata
+- keep manual notes in full until deleted
+- keep flagged clips optionally
+- prompt user after long meetings or valuable captures:
+  - keep summary only
+  - keep summary + key clips
+  - keep full audio
+  - delete audio and keep metadata
+
+## Battery behavior direction
+
+The device should not abruptly die mid-meeting if it can safely flush state first.
+
+Planned behavior:
+- warn in low battery zone
+- avoid starting long manual recordings when battery is already too low
+- on critical battery, safely close files and persist session/sync state before protected shutdown
+
+## Build + flash
+
+1. Install Arduino IDE 2.x
+2. Add ESP32 board support
+3. Select XIAO ESP32S3
+4. Select OPI PSRAM
+5. Select partition scheme appropriate for current firmware size
+6. Upload over USB-C
+
+## Next step
+
+Before Phase D, complete **Phase C hardening**: persistence, reconnect/resync, battery truth, session semantics, sync backlog model, and test coverage.
+
+## License
+
+MIT


### PR DESCRIPTION
## What
Add concrete planning docs for the Phase C hardening pass before Phase D AI/coaching work.

Includes:
- `PHASE_C_HARDENING.md` with sync, audio retention, battery, cloud, and testing decisions
- `README_REFRESH.md` as a refreshed README draft for the current product state
- `PHASE_PLAN_VNEXT.md` as a drop-in proposed next phase plan

## Why
The current repo has working firmware + app surfaces, but the next step needs a tighter box around:
- session semantics
- reconnect/resync behavior
- battery/power safety
- metadata vs audio retention
- cloud foundation
- test + edge-case coverage

This PR is intended as the source-of-truth handoff for implementation tickets and Claude Code follow-up work.